### PR TITLE
Remove type for ami

### DIFF
--- a/ecs-v2.cfhighlander.rb
+++ b/ecs-v2.cfhighlander.rb
@@ -20,8 +20,7 @@ CfhighlanderTemplate do
       
       ComponentParam 'KeyPair'
       
-      ComponentParam 'Ami', '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id', 
-          type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+      ComponentParam 'Ami'
       
       ComponentParam 'InstanceType', 't3.small'
       


### PR DESCRIPTION
We are unable to set the ami parameter to anything other than an ssm param, the type over-ride in cfhighlander does not work