### PR TITLE
Change iptables save command to the correct command

### DIFF
--- a/ecs-v2.cfndsl.rb
+++ b/ecs-v2.cfndsl.rb
@@ -72,7 +72,7 @@ CloudFormation do
     instance_userdata = <<~USERDATA
     #!/bin/bash
     iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP
-    service iptables save
+    iptables-save
     echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config
     USERDATA
     


### PR DESCRIPTION
I tried using the service command on an amazon linux 2 instance and it didn't work, using `iptables-save` did so I presume this is the correct command to use, for linux 2 at least.